### PR TITLE
Redis Throughput Simulate

### DIFF
--- a/api/handler.go
+++ b/api/handler.go
@@ -3,7 +3,10 @@ package api
 import (
 	"encoding/json"
 	"github.com/esperer/redisperf/redis"
+	"github.com/esperer/redisperf/test"
+	"github.com/esperer/redisperf/throughput"
 	"net/http"
+	"strconv"
 )
 
 var redisGateway = redisconfig.GetRedisGateWay()
@@ -26,7 +29,20 @@ func HandleHealthCheckRedisHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func HandleSimulateFailover(w http.ResponseWriter, r *http.Request) {
-
+	config, err := test.LoadConfig()
+	if err != nil {
+		response := map[string]string{"message": "Throughput Test Failed Because Can'not load Test Config"}
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(response)
+	}
+	requestCount, averageDuration, totalDuration := throughput.PrintThroughputResults(config)
+	w.WriteHeader(http.StatusOK)
+	response := map[string]string{
+		"requestCount":    strconv.Itoa(requestCount),
+		"averageDuration": averageDuration.String(),
+		"totalDuration":   totalDuration.String(),
+	}
+	json.NewEncoder(w).Encode(response)
 }
 
 func HandleSimulateThroughput(w http.ResponseWriter, r *http.Request) {

--- a/api/handler.go
+++ b/api/handler.go
@@ -2,9 +2,11 @@ package api
 
 import (
 	"encoding/json"
+	"fmt"
 	"github.com/esperer/redisperf/redis"
 	"github.com/esperer/redisperf/test"
 	"github.com/esperer/redisperf/throughput"
+	"log"
 	"net/http"
 	"strconv"
 )
@@ -28,24 +30,27 @@ func HandleHealthCheckRedisHandler(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(response)
 }
 
-func HandleSimulateFailover(w http.ResponseWriter, r *http.Request) {
+func HandleSimulateThroughput(w http.ResponseWriter, r *http.Request) {
+	fmt.Printf("원욱이")
 	config, err := test.LoadConfig()
 	if err != nil {
 		response := map[string]string{"message": "Throughput Test Failed Because Can'not load Test Config"}
 		w.WriteHeader(http.StatusInternalServerError)
 		json.NewEncoder(w).Encode(response)
+		log.Println(err)
+		return
 	}
 	requestCount, averageDuration, totalDuration := throughput.PrintThroughputResults(config)
-	w.WriteHeader(http.StatusOK)
 	response := map[string]string{
-		"requestCount":    strconv.Itoa(requestCount),
+		"requestCount":    strconv.Itoa(requestCount) + "req",
 		"averageDuration": averageDuration.String(),
 		"totalDuration":   totalDuration.String(),
 	}
+	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(response)
 }
 
-func HandleSimulateThroughput(w http.ResponseWriter, r *http.Request) {
+func HandleSimulateFailover(w http.ResponseWriter, r *http.Request) {
 
 }
 

--- a/config.yaml
+++ b/config.yaml
@@ -1,9 +1,8 @@
-redis:
-  address: "localhost:6379"
-  password: ""         # Redis password if set
-  db: 0                # Database index
-  maxMemoryPolicy: "allkeys-lru"  # Redis eviction policy for TTL tests
-test:
-  throughput: 10000       # Number of requests for throughput test
-  ttl: 5     # TTL values in seconds for keys
-  failover: true        # Enable failover testing
+address: "localhost:6379"
+password: ""         # Redis password if set
+db: 0                # Database index
+maxMemoryPolicy: "allkeys-lru"  # Redis eviction policy for TTL tests
+
+throughput: 10000       # Number of requests for throughput test
+ttl: 5     # TTL values in seconds for keys
+failover: true        # Enable failover testing

--- a/failover/simulate.go
+++ b/failover/simulate.go
@@ -1,4 +1,4 @@
-package ttl
+package failover
 
 func main() {
 

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"github.com/esperer/redisperf/api"
 	"github.com/esperer/redisperf/redis"
 	"github.com/redis/go-redis/v9"
@@ -10,10 +11,12 @@ import (
 var redisClient *redis.Client
 
 func main() {
+
 	api.Run()
 	config, err := redisconfig.LoadConfig()
 	if err != nil {
 		log.Fatalf("Error loading config: %v", err)
 	}
 	redisClient = redisconfig.ConnectRedis(config)
+	fmt.Printf("Server Up Redis Address: %s", config.Address)
 }

--- a/redis/connection.go
+++ b/redis/connection.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"github.com/redis/go-redis/v9"
 	"gopkg.in/yaml.v3"
-	"io/ioutil"
 	"log"
+	"os"
 	"path/filepath"
 	"time"
 )
@@ -15,21 +15,20 @@ var redisClient *redis.Client
 var ctx = context.Background()
 
 type RedisConfig struct {
-	Address         string `yaml:address`
-	Password        string `yaml:password`
-	DB              int    `yaml:db`
-	MaxMemoryPolicy string `yaml:maxMemoryPolicy`
+	Address         string `yaml:"address"`
+	Password        string `yaml:"password"`
+	DB              int    `yaml:"db"`
+	MaxMemoryPolicy string `yaml:"maxMemoryPolicy"`
 }
 
 func LoadConfig() (*RedisConfig, error) {
-	filename, _ := filepath.Abs("config/config.yml")
-	yamlFile, err := ioutil.ReadFile(filename)
+	filename, _ := filepath.Abs("./config.yaml")
+	yamlFile, err := os.ReadFile(filename)
 	var config RedisConfig
 	err = yaml.Unmarshal(yamlFile, &config)
 	if err != nil {
 		return nil, err
 	}
-
 	return &config, nil
 }
 

--- a/test/config.go
+++ b/test/config.go
@@ -1,24 +1,32 @@
 package test
 
 import (
+	"fmt"
 	"gopkg.in/yaml.v3"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 )
 
+type Config struct {
+	Test TestConfig `yaml:"test"`
+}
+
 type TestConfig struct {
-	Throughput int  `yaml:throughput`
-	TTL        int  `yaml:ttl`
-	Failover   bool `yaml:failover`
+	Throughput int  `yaml:"throughput"`
+	TTL        int  `yaml:"ttl"`
+	Failover   bool `yaml:"failover"`
 }
 
 func LoadConfig() (*TestConfig, error) {
-	filename, _ := filepath.Abs("config/config.yml")
-	yamlFile, err := ioutil.ReadFile(filename)
+	filename, _ := filepath.Abs("./config.yaml")
+	yamlFile, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, fmt.Errorf("error reading yaml os: %w", err)
+	}
 	var config TestConfig
 	err = yaml.Unmarshal(yamlFile, &config)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error reading yaml unmarshal: %w", err)
 	}
 
 	return &config, nil

--- a/throughput/simulate.go
+++ b/throughput/simulate.go
@@ -42,7 +42,7 @@ func PrintThroughputResults(config *test.TestConfig) (int, time.Duration, time.D
 	averageDuration := totalDuration / time.Duration(keyCount)
 	fmt.Println("\n--- Throughput Test Results ---")
 	fmt.Printf("Total Keys: %d\n", keyCount)
-	fmt.Printf("Total Request Count %d\n", requestCount)
+	fmt.Printf("Total Request Count %dreq\n", requestCount)
 	fmt.Printf("Total Duration: %v\n", totalDuration)
 	fmt.Printf("Average Request Duration: %v\n", averageDuration)
 	fmt.Println("--------------------------------")

--- a/throughput/simulate.go
+++ b/throughput/simulate.go
@@ -23,7 +23,7 @@ func PrintThroughputResults(config *test.TestConfig) (int, time.Duration, time.D
 		}
 	}
 	// Measure time taken for each GET request
-	for i := 1; i <= requestCount; i++ {
+	for i := 0; i < requestCount; i++ {
 		key := fmt.Sprintf("test_key_%d", (i%keyCount)+1)
 		reqStart := time.Now()
 		_, err := redisGateway.GetData(key)
@@ -31,8 +31,8 @@ func PrintThroughputResults(config *test.TestConfig) (int, time.Duration, time.D
 		if err != nil {
 			log.Printf("Failed to get key %s: %v\n", key, err)
 		}
-		individualTimes[i-1] = reqEnd
-		fmt.Printf("Request %d for key %s completed in: %v\n", i, key, reqEnd)
+		individualTimes[(i % keyCount)] = reqEnd
+		//fmt.Printf("Request %d for key %s completed in: %v\n", i, key, reqEnd)
 	}
 	// Calculate total and average duration
 	var totalDuration time.Duration
@@ -42,6 +42,7 @@ func PrintThroughputResults(config *test.TestConfig) (int, time.Duration, time.D
 	averageDuration := totalDuration / time.Duration(keyCount)
 	fmt.Println("\n--- Throughput Test Results ---")
 	fmt.Printf("Total Keys: %d\n", keyCount)
+	fmt.Printf("Total Request Count %d\n", requestCount)
 	fmt.Printf("Total Duration: %v\n", totalDuration)
 	fmt.Printf("Average Request Duration: %v\n", averageDuration)
 	fmt.Println("--------------------------------")


### PR DESCRIPTION
## Type Of PR
Implement Redis Throughput Simulate Handler 

### Simulate

This is a simulation that iterates through **30 keys** based on the throughput size specified in the config.yaml and returns the average and total values upon completion. It would also be good to add a feature to abort in case of a GET failure. The usage method is to send a `GET` request to `/throughput.`


### Results
<img width="552" alt="image" src="https://github.com/user-attachments/assets/5e595382-b937-4e3c-83bb-f346e5b55549">

<img width="338" alt="image" src="https://github.com/user-attachments/assets/2fd43220-8eb5-43a2-a25e-2c09cd253a3e">

